### PR TITLE
Improve data structure of storage configuration

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,7 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/giginet/scipio-cache-storage.git",
       "state" : {
-        "revision" : "ec3467983ae14356ffcba0ecf4e5c76c3dd80532"
+        "revision" : "a7b01bbf02dea506af7d8f7a13f6e985044d5d57",
+        "version" : "1.0.0"
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -13,18 +13,15 @@ import ScipioKit
 import ScipioS3Storage
 
 // Define S3 Storage settings
-let config = S3StorageConfig(
-    authenticationMode: .authorized(
-        accessKeyID: "AWS_ACCESS_KEY_ID", 
-        secretAccessKey: "AWS_SECRET_ACCESS_KEY"
-    ),
+let config = AuthorizedConfiguration(
     bucket: "my-bucket",
     region: "ap-northeast-1",
-    endpoint: URL(string: "https://my-s3-bucket.com")!
+    accessKeyID: "AWS_ACCESS_KEY_ID",
+    secretAccessKey: "AWS_SECRET_ACCESS_KEY"
 )
 
 // Instantiate S3Storage
-let s3Storage = try S3Storage(config: config)
+let s3Storage = try S3Storage(config: .authorized(config))
 
 // Define Scipio Runner options
 let options = Runner.Options(

--- a/Sources/ScipioS3Storage/S3Client.swift
+++ b/Sources/ScipioS3Storage/S3Client.swift
@@ -116,7 +116,7 @@ struct PublicURLObjectStorageClient: ObjectStorageClient {
     }
 
     func isExistObject(at key: String) async throws -> Bool {
-        let url = try constructPublicURL(of: key)
+        let url = constructPublicURL(of: key)
         let request = {
             var request = URLRequest(url: url)
             request.httpMethod = "HEAD"
@@ -131,7 +131,7 @@ struct PublicURLObjectStorageClient: ObjectStorageClient {
     }
 
     func fetchObject(at key: String) async throws -> Data {
-        let url = try constructPublicURL(of: key)
+        let url = constructPublicURL(of: key)
         let request = URLRequest(url: url)
         let (data, httpResponse) = try await httpClient.data(for: request)
 
@@ -142,7 +142,7 @@ struct PublicURLObjectStorageClient: ObjectStorageClient {
         return data
     }
 
-    private func constructPublicURL(of key: String) throws -> URL {
+    private func constructPublicURL(of key: String) -> URL {
         endpoint.appendingPathComponent(bucket)
             .appendingPathComponent(key)
     }

--- a/Sources/ScipioS3Storage/S3Client.swift
+++ b/Sources/ScipioS3Storage/S3Client.swift
@@ -31,10 +31,14 @@ actor APIObjectStorageClient: ObjectStorageClient {
             ),
             httpClientProvider: .createNew
         )
+        let endpointURL: URL? = switch config.endpoint {
+        case .awsDefault: nil
+        case .custom(let url): url
+        }
         self.client = S3(
             client: awsClient,
             region: .init(awsRegionName: config.region),
-            endpoint: config.endpoint?.absoluteString
+            endpoint: endpointURL?.absoluteString
         )
         self.config = config
     }

--- a/Sources/ScipioS3Storage/S3Client.swift
+++ b/Sources/ScipioS3Storage/S3Client.swift
@@ -61,12 +61,10 @@ actor APIObjectStorageClient: ObjectStorageClient {
         )
         do {
             _ = try await client.headObject(headObjectRequest)
+            return true
         } catch let error as S3ErrorType where error == .notFound {
             return false
-        } catch {
-            throw error
         }
-        return true
     }
 
     func fetchObject(at key: String) async throws -> Data {

--- a/Sources/ScipioS3Storage/S3Storage.swift
+++ b/Sources/ScipioS3Storage/S3Storage.swift
@@ -17,8 +17,7 @@ public struct AuthorizedConfiguration: Sendable {
     public var region: String
 
     /// An endpoint to the S3.
-    /// When `nil` is passed, the url is guessed according to the given region.
-    public var endpoint: URL?
+    public var endpoint: Endpoint
 
     /// A boolean value indicating an object should be published or not when it's put.
     public var shouldPublishObject: Bool
@@ -33,15 +32,15 @@ public struct AuthorizedConfiguration: Sendable {
     /// - Parameters:
     ///   - bucket: A bucket name
     ///   - region: A region of the S3 bucket
-    ///   - endpoint: An endpoint to the S3. When `nil` is passed, the url is guessed according to the given region.
+    ///   - endpoint: An endpoint to the S3.
     ///   - shouldPublishObject: A boolean value indicating an object should be published or not when it's put.
     ///   - accessKeyID: An access key.
     ///   - secretAccessKey: A secret access key
     public init(
         bucket: String,
         region: String,
-        endpoint: URL?,
-        shouldPublishObject: Bool,
+        endpoint: Endpoint = .awsDefault,
+        shouldPublishObject: Bool = false,
         accessKeyID: String,
         secretAccessKey: String
     ) {
@@ -51,6 +50,16 @@ public struct AuthorizedConfiguration: Sendable {
         self.shouldPublishObject = shouldPublishObject
         self.accessKeyID = accessKeyID
         self.secretAccessKey = secretAccessKey
+    }
+}
+
+extension AuthorizedConfiguration {
+    public enum Endpoint: Sendable {
+        /// A case indicating default URL of AWS. The url is guessed according to the given region.
+        case awsDefault
+
+        /// A case indicating custom URL.
+        case custom(URL)
     }
 }
 

--- a/Sources/ScipioS3Storage/S3Storage.swift
+++ b/Sources/ScipioS3Storage/S3Storage.swift
@@ -28,7 +28,15 @@ public struct AuthorizedConfiguration: Sendable {
 
     /// A secret access key
     public var secretAccessKey: String
-
+    
+    /// Makes a configuration.
+    /// - Parameters:
+    ///   - bucket: A bucket name
+    ///   - region: A region of the S3 bucket
+    ///   - endpoint: An endpoint to the S3. When `nil` is passed, the url is guessed according to the given region.
+    ///   - shouldPublishObject: A boolean value indicating an object should be published or not when it's put.
+    ///   - accessKeyID: An access key.
+    ///   - secretAccessKey: A secret access key
     public init(
         bucket: String,
         region: String,
@@ -61,11 +69,7 @@ public actor S3Storage: CacheStorage {
 
     public func existsValidCache(for cacheKey: some CacheKey) async throws -> Bool {
         let objectStorageKey = try constructObjectStorageKey(from: cacheKey)
-        do {
-            return try await storageClient.isExistObject(at: objectStorageKey)
-        } catch {
-            throw error
-        }
+        return try await storageClient.isExistObject(at: objectStorageKey)
     }
 
     public func fetchArtifacts(for cacheKey: some CacheKey, to destinationDir: URL) async throws {

--- a/Sources/ScipioS3Storage/S3Storage.swift
+++ b/Sources/ScipioS3Storage/S3Storage.swift
@@ -27,7 +27,7 @@ public struct AuthorizedConfiguration: Sendable {
 
     /// A secret access key
     public var secretAccessKey: String
-    
+
     /// Makes a configuration.
     /// - Parameters:
     ///   - bucket: A bucket name

--- a/Tests/ScipioS3StorageTests/AARArchiverTests.swift
+++ b/Tests/ScipioS3StorageTests/AARArchiverTests.swift
@@ -34,7 +34,7 @@ final class AARArchiverTests: XCTestCase {
             fileManager.contents(atPath: extractedPath.appendingPathComponent(fileName).path)
         )
         XCTAssertEqual(
-            String(data: fileContents, encoding: .utf8),
+            String(decoding: fileContents, as: UTF8.self),
             fileBody
         )
     }

--- a/Tests/ScipioS3StorageTests/AARArchiverTests.swift
+++ b/Tests/ScipioS3StorageTests/AARArchiverTests.swift
@@ -34,7 +34,7 @@ final class AARArchiverTests: XCTestCase {
             fileManager.contents(atPath: extractedPath.appendingPathComponent(fileName).path)
         )
         XCTAssertEqual(
-            String(decoding: fileContents, as: UTF8.self),
+            String(bytes: fileContents, encoding: .utf8),
             fileBody
         )
     }

--- a/Tests/ScipioS3StorageTests/CompressorTests.swift
+++ b/Tests/ScipioS3StorageTests/CompressorTests.swift
@@ -38,7 +38,7 @@ final class CompressorTests: XCTestCase {
             fileManager.contents(atPath: extractedPath.appendingPathComponent(fileName).path)
         )
         XCTAssertEqual(
-            String(data: fileContents, encoding: .utf8),
+            String(decoding: fileContents, as: UTF8.self),
             fileBody
         )
 

--- a/Tests/ScipioS3StorageTests/CompressorTests.swift
+++ b/Tests/ScipioS3StorageTests/CompressorTests.swift
@@ -38,7 +38,7 @@ final class CompressorTests: XCTestCase {
             fileManager.contents(atPath: extractedPath.appendingPathComponent(fileName).path)
         )
         XCTAssertEqual(
-            String(decoding: fileContents, as: UTF8.self),
+            String(bytes: fileContents, encoding: .utf8),
             fileBody
         )
 


### PR DESCRIPTION
## Changes
- Makes `S3StorageConfig` an enum having associated values.
- Add documents to a new configuration
- Minor code improvement.

## Details
### Motivation
`S3StorageConfig` requires an endpoint as a non-optional url.
However, it is not useful in a situation where developer wants to access AWS S3, because the developer needs to know the endpoint even though soto can estimate it.
To fix the issue, I would like to make `endpoint` optional value for `APIObjectStorageClient`.

### Insights
As I mentioned above, `APIObjectStorageClient` doesn't require an endpoint as a non-optional value.
However, on the other hand, `PublicURLObjectStorageClient` requires it.

And through code reading, `S3StorageConfig` has several properties but most of them are required by only `APIObjectStorageClient` and `PublicURLObjectStorageClient` requires only an endpoint and a bucket name.

That's a reason why I made `S3StorageConfig` an enum having associated values.
Thanks to the changes, I could remove a `fatalError` in `APIObjectStorageClient`.

### Concerns
This is breaking changes, so I don't know you can accept this PR.