### PR TITLE
Migrate `scipio-cache-storage` to `ScipioCacheStorage` in Scipio package

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "337ab6b866683fcaa51627be7b281e3182bf02cf5559eb5fc4e254a08f5e2b6a",
+  "originHash" : "d107ec1e0a398f29800633b6ec2c0a273b6ea3418f59bd6d1588e45d136f9434",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/giginet/Scipio.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "8d03b71c8d7a9a60dfd2960b137307b866280b62"
+        "revision" : "d4131d082ca9ffb797380357edd5bf744ff86a91",
+        "version" : "0.32.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4165d778ddf9c9d50ab2940615681d100d36321aa57c67136d1bc06193910d1a",
+  "originHash" : "337ab6b866683fcaa51627be7b281e3182bf02cf5559eb5fc4e254a08f5e2b6a",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -20,12 +20,30 @@
       }
     },
     {
-      "identity" : "scipio-cache-storage",
+      "identity" : "packagemanifestkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/giginet/scipio-cache-storage.git",
+      "location" : "https://github.com/giginet/PackageManifestKit",
       "state" : {
-        "revision" : "a7b01bbf02dea506af7d8f7a13f6e985044d5d57",
-        "version" : "1.0.0"
+        "revision" : "b68ef7e92003a757c8d0f1c1fc4e34d48963c311",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "rainbow",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Rainbow",
+      "state" : {
+        "revision" : "16da5c62dd737258c6df2e8c430f8a3202f655a7",
+        "version" : "4.2.0"
+      }
+    },
+    {
+      "identity" : "scipio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/giginet/Scipio.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "8d03b71c8d7a9a60dfd2960b137307b866280b62"
       }
     },
     {
@@ -80,6 +98,15 @@
       "state" : {
         "revision" : "7faebca1ea4f9aaf0cda1cef7c43aecd2311ddf6",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-async-operations",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mtj0928/swift-async-operations.git",
+      "state" : {
+        "revision" : "21bac5f70f74ef4fbe4c8aaa13b27e99e2331436",
+        "version" : "0.4.0"
       }
     },
     {
@@ -224,6 +251,15 @@
       "state" : {
         "revision" : "a34201439c74b53f0fd71ef11741af7e7caf01e1",
         "version" : "1.4.2"
+      }
+    },
+    {
+      "identity" : "swiftyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftyJSON/SwiftyJSON.git",
+      "state" : {
+        "revision" : "af76cf3ef710b6ca5f8c05f3a31307d44a3c5828",
+        "version" : "5.0.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -18,14 +18,14 @@ let package = Package(
                  from: "7.1.0"),
         .package(url: "https://github.com/soto-project/soto-core.git",
                  from: "7.3.2"),
-        .package(url: "https://github.com/giginet/scipio-cache-storage.git",
-                 from: "1.0.0"),
+        .package(url: "https://github.com/giginet/Scipio.git",
+                 branch: "main"),
     ],
     targets: [
         .target(
             name: "ScipioS3Storage",
             dependencies: [
-                .product(name: "ScipioStorage", package: "scipio-cache-storage"),
+                .product(name: "ScipioCacheStorage", package: "Scipio"),
                 .product(name: "SotoCore", package: "soto-core"),
             ],
             plugins: [

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/soto-project/soto-core.git",
                  from: "7.3.2"),
         .package(url: "https://github.com/giginet/Scipio.git",
-                 branch: "main"),
+                 from: "0.32.0"),
     ],
     targets: [
         .target(

--- a/Sources/ScipioS3Storage/S3Storage.swift
+++ b/Sources/ScipioS3Storage/S3Storage.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ScipioStorage
+import CacheStorage
 
 public enum S3StorageConfig: Sendable {
     /// A configuration which requires authentication.
@@ -63,7 +63,7 @@ extension AuthorizedConfiguration {
     }
 }
 
-public actor S3Storage: CacheStorage {
+public actor S3Storage: FrameworkCacheStorage {
     private let storagePrefix: String?
     private let storageClient: any ObjectStorageClient
     private let compressor = Compressor()


### PR DESCRIPTION
Scipio has been migrated from [giginet/scipio-cache-storage](https://github.com/giginet/scipio-cache-storage) to a new module named `ScipioCacheStorage` within the Scipio package by https://github.com/giginet/Scipio/pull/251.

Therefore, in this pr, I've switched from [giginet/scipio-cache-storage](https://github.com/giginet/scipio-cache-storage) to the `ScipioCacheStorage` product.