### PR TITLE
Add S3ResolvedPackagesStorage

### DIFF
--- a/Sources/ScipioS3Storage/S3Client.swift
+++ b/Sources/ScipioS3Storage/S3Client.swift
@@ -1,5 +1,6 @@
 import Foundation
-import SotoCore
+@testable import SotoCore
+import AsyncHTTPClient
 
 protocol ObjectStorageClient: Sendable {
     func putObject(_ data: Data, at key: String) async throws
@@ -37,7 +38,8 @@ actor APIObjectStorageClient: ObjectStorageClient {
         self.client = S3(
             client: awsClient,
             region: .init(awsRegionName: config.region),
-            endpoint: endpointURL?.absoluteString
+            endpoint: endpointURL?.absoluteString,
+            timeout: .minutes(1)
         )
         self.config = config
     }

--- a/Sources/ScipioS3Storage/S3Client.swift
+++ b/Sources/ScipioS3Storage/S3Client.swift
@@ -1,6 +1,5 @@
 import Foundation
 import SotoCore
-import AsyncHTTPClient
 
 protocol ObjectStorageClient: Sendable {
     func putObject(_ data: Data, at key: String) async throws

--- a/Sources/ScipioS3Storage/S3FrameworkStorage.swift
+++ b/Sources/ScipioS3Storage/S3FrameworkStorage.swift
@@ -1,69 +1,8 @@
 import Foundation
 import CacheStorage
+import struct UniformTypeIdentifiers.UTType
 
-public enum S3StorageConfig: Sendable {
-    /// A configuration which requires authentication.
-    case authorized(AuthorizedConfiguration)
-
-    /// A configuration for a public storage.
-    case publicURL(endpoint: URL, bucket: String)
-}
-
-public struct AuthorizedConfiguration: Sendable {
-    /// A bucket name
-    public var bucket: String
-
-    /// A region of the S3 bucket
-    public var region: String
-
-    /// An endpoint to the S3.
-    public var endpoint: Endpoint
-
-    /// A boolean value indicating an object should be published or not when it's put.
-    public var shouldPublishObject: Bool
-
-    /// An access key.
-    public var accessKeyID: String
-
-    /// A secret access key
-    public var secretAccessKey: String
-
-    /// Makes a configuration.
-    /// - Parameters:
-    ///   - bucket: A bucket name
-    ///   - region: A region of the S3 bucket
-    ///   - endpoint: An endpoint to the S3.
-    ///   - shouldPublishObject: A boolean value indicating an object should be published or not when it's put.
-    ///   - accessKeyID: An access key.
-    ///   - secretAccessKey: A secret access key
-    public init(
-        bucket: String,
-        region: String,
-        endpoint: Endpoint = .awsDefault,
-        shouldPublishObject: Bool = false,
-        accessKeyID: String,
-        secretAccessKey: String
-    ) {
-        self.region = region
-        self.bucket = bucket
-        self.endpoint = endpoint
-        self.shouldPublishObject = shouldPublishObject
-        self.accessKeyID = accessKeyID
-        self.secretAccessKey = secretAccessKey
-    }
-}
-
-extension AuthorizedConfiguration {
-    public enum Endpoint: Sendable {
-        /// A case indicating default URL of AWS. The url is guessed according to the given region.
-        case awsDefault
-
-        /// A case indicating custom URL.
-        case custom(URL)
-    }
-}
-
-public actor S3Storage: FrameworkCacheStorage {
+public actor S3FrameworkStorage: FrameworkCacheStorage {
     private let storagePrefix: String?
     private let storageClient: any ObjectStorageClient
     private let compressor = Compressor()
@@ -103,3 +42,6 @@ public actor S3Storage: FrameworkCacheStorage {
             .joined(separator: "/")
     }
 }
+
+@available(*, deprecated, renamed: "S3FrameworkStorage")
+public typealias S3Storage = S3FrameworkStorage

--- a/Sources/ScipioS3Storage/S3FrameworkStorage.swift
+++ b/Sources/ScipioS3Storage/S3FrameworkStorage.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CacheStorage
+import SotoCore
 import struct UniformTypeIdentifiers.UTType
 
 public actor S3FrameworkStorage: FrameworkCacheStorage {
@@ -7,10 +8,14 @@ public actor S3FrameworkStorage: FrameworkCacheStorage {
     private let storageClient: any ObjectStorageClient
     private let compressor = Compressor()
 
-    public init(config: S3StorageConfig, storagePrefix: String? = nil) throws {
+    public init(
+        config: S3StorageConfig,
+        storagePrefix: String? = nil,
+        timeout: TimeAmount? = nil
+    ) throws {
         self.storageClient = switch config {
-        case .publicURL(let endpoint, let bucket): PublicURLObjectStorageClient(endpoint: endpoint, bucket: bucket)
-        case .authorized(let authorizedConfiguration): APIObjectStorageClient(authorizedConfiguration)
+        case .publicURL(let endpoint, let bucket): PublicURLObjectStorageClient(endpoint: endpoint, bucket: bucket, timeout: timeout)
+        case .authorized(let authorizedConfiguration): APIObjectStorageClient(authorizedConfiguration, timeout: timeout)
         }
         self.storagePrefix = storagePrefix
     }

--- a/Sources/ScipioS3Storage/S3FrameworkStorage.swift
+++ b/Sources/ScipioS3Storage/S3FrameworkStorage.swift
@@ -14,8 +14,10 @@ public actor S3FrameworkStorage: FrameworkCacheStorage {
         timeout: TimeAmount? = nil
     ) throws {
         self.storageClient = switch config {
-        case .publicURL(let endpoint, let bucket): PublicURLObjectStorageClient(endpoint: endpoint, bucket: bucket, timeout: timeout)
-        case .authorized(let authorizedConfiguration): APIObjectStorageClient(authorizedConfiguration, timeout: timeout)
+        case .publicURL(let endpoint, let bucket):
+            PublicURLObjectStorageClient(endpoint: endpoint, bucket: bucket, timeout: timeout)
+        case .authorized(let authorizedConfiguration):
+            APIObjectStorageClient(authorizedConfiguration, timeout: timeout)
         }
         self.storagePrefix = storagePrefix
     }

--- a/Sources/ScipioS3Storage/S3ResolvedPackagesCacheStorage.swift
+++ b/Sources/ScipioS3Storage/S3ResolvedPackagesCacheStorage.swift
@@ -1,0 +1,38 @@
+import Foundation
+import CacheStorage
+
+public actor S3ResolvedPackagesCacheStorage: ResolvedPackagesCacheStorage {
+    private let jsonDecoder = JSONDecoder()
+    private let jsonEncoder = JSONEncoder()
+
+    private let storageClient: any ObjectStorageClient
+    private let fileManager: FileManager = .default
+
+    public init(config: S3StorageConfig) throws {
+        self.storageClient = switch config {
+        case .publicURL(let endpoint, let bucket): PublicURLObjectStorageClient(endpoint: endpoint, bucket: bucket)
+        case .authorized(let authorizedConfiguration): APIObjectStorageClient(authorizedConfiguration)
+        }
+    }
+
+    public func fetchResolvedPackages(for originHash: String) async throws -> [ResolvedPackage] {
+        let objectStorageKey = constructObjectStorageKey(from: originHash)
+        let archiveData = try await storageClient.fetchObject(at: objectStorageKey)
+        return try jsonDecoder.decode([ResolvedPackage].self, from: archiveData)
+    }
+
+    public func cacheResolvedPackages(_ resolvedPackages: [ResolvedPackage], for originHash: String) async throws {
+        let data = try jsonEncoder.encode(resolvedPackages)
+        let objectStorageKey = constructObjectStorageKey(from: originHash)
+        try await storageClient.putObject(data, at: objectStorageKey)
+    }
+
+    public func existsValidCache(for originHash: String) async throws -> Bool {
+        let objectStorageKey = constructObjectStorageKey(from: originHash)
+        return try await storageClient.isExistObject(at: objectStorageKey)
+    }
+
+    private func constructObjectStorageKey(from originHash: String) -> String {
+        "ResolvedPackages_\(originHash)"
+    }
+}

--- a/Sources/ScipioS3Storage/S3ResolvedPackagesCacheStorage.swift
+++ b/Sources/ScipioS3Storage/S3ResolvedPackagesCacheStorage.swift
@@ -16,8 +16,10 @@ public actor S3ResolvedPackagesStorage: ResolvedPackagesCacheStorage {
     ) throws {
         self.storagePrefix = storagePrefix
         self.storageClient = switch config {
-        case .publicURL(let endpoint, let bucket): PublicURLObjectStorageClient(endpoint: endpoint, bucket: bucket, timeout: timeout)
-        case .authorized(let authorizedConfiguration): APIObjectStorageClient(authorizedConfiguration, timeout: timeout)
+        case .publicURL(let endpoint, let bucket):
+            PublicURLObjectStorageClient(endpoint: endpoint, bucket: bucket, timeout: timeout)
+        case .authorized(let authorizedConfiguration):
+            APIObjectStorageClient(authorizedConfiguration, timeout: timeout)
         }
     }
 

--- a/Sources/ScipioS3Storage/S3StorageConfig.swift
+++ b/Sources/ScipioS3Storage/S3StorageConfig.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+public enum S3StorageConfig: Sendable {
+    /// A configuration which requires authentication.
+    case authorized(AuthorizedConfiguration)
+
+    /// A configuration for a public storage.
+    case publicURL(endpoint: URL, bucket: String)
+}
+
+public struct AuthorizedConfiguration: Sendable {
+    /// A bucket name
+    public var bucket: String
+
+    /// A region of the S3 bucket
+    public var region: String
+
+    /// An endpoint to the S3.
+    public var endpoint: Endpoint
+
+    /// A boolean value indicating an object should be published or not when it's put.
+    public var shouldPublishObject: Bool
+
+    /// An access key.
+    public var accessKeyID: String
+
+    /// A secret access key
+    public var secretAccessKey: String
+
+    /// Makes a configuration.
+    /// - Parameters:
+    ///   - bucket: A bucket name
+    ///   - region: A region of the S3 bucket
+    ///   - endpoint: An endpoint to the S3.
+    ///   - shouldPublishObject: A boolean value indicating an object should be published or not when it's put.
+    ///   - accessKeyID: An access key.
+    ///   - secretAccessKey: A secret access key
+    public init(
+        bucket: String,
+        region: String,
+        endpoint: Endpoint = .awsDefault,
+        shouldPublishObject: Bool = false,
+        accessKeyID: String,
+        secretAccessKey: String
+    ) {
+        self.region = region
+        self.bucket = bucket
+        self.endpoint = endpoint
+        self.shouldPublishObject = shouldPublishObject
+        self.accessKeyID = accessKeyID
+        self.secretAccessKey = secretAccessKey
+    }
+}
+
+extension AuthorizedConfiguration {
+    public enum Endpoint: Sendable {
+        /// A case indicating default URL of AWS. The url is guessed according to the given region.
+        case awsDefault
+
+        /// A case indicating custom URL.
+        case custom(URL)
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds `S3ResolvedPackagesStorage` and introduces configurable timeout settings for S3 operations. Since resolved packages can be large, they sometimes exceeded the default 20-second timeout. The timeout parameter has also been added to `S3FrameworkStorage` and `PublicURLObjectStorageClient` for API consistency.

## Changes

- Added `S3ResolvedPackagesStorage` for caching resolved packages
- Added configurable `timeout` parameter to all storage implementations
- Split `S3StorageConfig` and `AuthorizedConfiguration` into separate files